### PR TITLE
Forget JS closure so it isn't dropped.

### DIFF
--- a/src/web/web_sys.rs
+++ b/src/web/web_sys.rs
@@ -33,9 +33,10 @@ fn poll_request(
         *have_set_handlers = true;
         let waker = ctx.waker().clone();
         let wake_up = Closure::wrap(Box::new(move || waker.wake_by_ref()) as Box<dyn FnMut()>);
-        let wake_up = wake_up.as_ref().unchecked_ref();
-        xhr.set_onload(Some(&wake_up));
-        xhr.set_onerror(Some(&wake_up));
+        let wake_up_ref = wake_up.as_ref().unchecked_ref();
+        xhr.set_onload(Some(&wake_up_ref));
+        xhr.set_onerror(Some(&wake_up_ref));
+        wake_up.forget();
     }
     let status = xhr
         .status()


### PR DESCRIPTION
Hey!

We should be leaking the closure we create for the XHR request. Otherwise it get's destroyed when it's dropped.

https://rustwasm.github.io/docs/wasm-bindgen/examples/closures.html